### PR TITLE
docs: fix typo in `getting-started.mdx`

### DIFF
--- a/docs/introduction/getting-started.mdx
+++ b/docs/introduction/getting-started.mdx
@@ -11,7 +11,7 @@ import logo from './logo.svg'
 
 ### Proxy state made simple.
 
-The Valtio API is minimal, flexible, unopinionated and a touch magical. Valtio's proxy turns the object you pass it into a self-aware proxy, allowing fine-grained subscription and creativity in making state updates. In React, Valtio shines at render optimization. It is compatible with Suspense and React 18. Valtio is also a viable option in vanilla javascript applications.
+The Valtio API is minimal, flexible, unopinionated and a touch magical. Valtio's proxy turns the object you pass it into a self-aware proxy, allowing fine-grained subscription and reactivity in making state updates. In React, Valtio shines at render optimization. It is compatible with Suspense and React 18. Valtio is also a viable option in vanilla javascript applications.
 
 #### Installation
 


### PR DESCRIPTION

## Summary
I think it's suppose to say "reactivity",  but I might be wrong


## Check List

- [x] `yarn run prettier` for formatting code and docs
